### PR TITLE
修复全景图跳转影响其他页面尺寸

### DIFF
--- a/frontend/src/views/Atomboard.vue
+++ b/frontend/src/views/Atomboard.vue
@@ -7,6 +7,8 @@
     },
     methods: {
       backToDetail() {
+        // 使用 transform scale
+        document.body.style.transform = '';
         this.$router.push({name: 'RankList'});
       }
     }


### PR DESCRIPTION
修复了从全景图跳转回其他页面后，其他页面的尺寸会被缩放的问题